### PR TITLE
Local alternate hrefs

### DIFF
--- a/titiler/stacapi/reader.py
+++ b/titiler/stacapi/reader.py
@@ -81,7 +81,7 @@ class STACReader(stac.STACReader):
 
         url = asset_info.get_absolute_href() or asset_info.href
         if alternate := stac_config.alternate_url:
-            url = asset_info.to_dict()["alternate"]["local"]["href"]
+            url = asset_info.to_dict()["alternate"][alternate]["href"]
 
         info = AssetInfo(
             url=url,

--- a/titiler/stacapi/reader.py
+++ b/titiler/stacapi/reader.py
@@ -81,7 +81,7 @@ class STACReader(stac.STACReader):
 
         url = asset_info.get_absolute_href() or asset_info.href
         if alternate := stac_config.alternate_url:
-            url = asset_info[alternate]["href"]
+            url = asset_info.to_dict()["alternate"]["local"]["href"]
 
         info = AssetInfo(
             url=url,


### PR DESCRIPTION
Fix alternate hrefs. `alternate` isn't an attribute of a pystac asset object, and also, we need to specify _which_ alternate href we want. Hard coded "local" for now, for my use case, but we probably need a syntax in the config to let the user specify this ? Or in the requests? 