### PR TITLE
Fix ghcr location in docker CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           file: dockerfiles/Dockerfile
           push: true
           tags: |
-            ghcr.io/stac-utils/titiler-stacapi:latest
+            ghcr.io/developmentseed/titiler-stacapi:latest
 
       # Push `{VERSION}` when pushing a new tag
       - name: Build and push tag
@@ -110,4 +110,4 @@ jobs:
           file: dockerfiles/Dockerfile
           push: true
           tags: |
-            ghcr.io/stac-utils/titiler-stacapi:${{ steps.tag.outputs.version }}
+            ghcr.io/developmentseed/titiler-stacapi:${{ steps.tag.outputs.version }}


### PR DESCRIPTION
In https://github.com/developmentseed/titiler-stacapi/pull/13 I specified the `stac-utils` repo group by mistake. We want to use `developmentseed`.  