### PR TITLE
switch to pystac client and add way to forward headers to the stac-api

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -6,9 +6,6 @@ from unittest.mock import patch
 
 import pystac
 import pytest
-from httpx import HTTPStatusError, RequestError
-
-from titiler.stacapi.dependencies import get_stac_item
 
 from .conftest import mock_rasterio_open
 
@@ -17,54 +14,14 @@ item_json = os.path.join(
 )
 
 
-class MockResponse:
-    """Mock HTTX response."""
-
-    def __init__(self, data):
-        """init."""
-        self.data = data
-
-    def raise_for_status(self):
-        """raise_for_status"""
-        pass
-
-    @property
-    def content(self):
-        """return content."""
-        return self.data
-
-    def json(self):
-        """return json."""
-        return json.loads(self.data)
-
-
-@patch("titiler.stacapi.dependencies.httpx")
-def test_get_stac_item(httpx):
-    """test get_stac_item."""
-
-    with open(item_json, "r") as f:
-        httpx.get.return_value = MockResponse(f.read())
-        httpx.HTTPStatusError = HTTPStatusError
-        httpx.RequestError = RequestError
-
-    item = get_stac_item(
-        "http://endpoint.stac", "noaa-emergency-response", "20200307aC0853900w361030"
-    )
-    assert isinstance(item, pystac.Item)
-    assert item.id == "20200307aC0853900w361030"
-    assert item.collection_id == "noaa-emergency-response"
-
-
 @patch("rio_tiler.io.rasterio.rasterio")
-@patch("titiler.stacapi.dependencies.httpx")
-def test_stac_items(httpx, rio, app):
+@patch("titiler.stacapi.dependencies.get_stac_item")
+def test_stac_items(get_stac_item, rio, app):
     """test STAC items endpoints."""
     rio.open = mock_rasterio_open
 
     with open(item_json, "r") as f:
-        httpx.get.return_value = MockResponse(f.read())
-        httpx.HTTPStatusError = HTTPStatusError
-        httpx.RequestError = RequestError
+        get_stac_item.return_value = pystac.Item.from_dict(json.loads(f.read()))
 
     response = app.get(
         "/collections/noaa-emergency-response/items/20200307aC0853900w361030/assets",

--- a/titiler/stacapi/dependencies.py
+++ b/titiler/stacapi/dependencies.py
@@ -1,18 +1,20 @@
 """titiler-stacapi dependencies."""
 
-from typing import Dict, List, Literal, Optional, get_args
+import json
+from typing import Dict, List, Literal, Optional, TypedDict, get_args
 
-import httpx
 import pystac
 from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
-from fastapi import Path, Query
+from fastapi import Depends, HTTPException, Path, Query
+from pystac_client import ItemSearch
+from pystac_client.stac_api_io import StacApiIO
 from starlette.requests import Request
 from typing_extensions import Annotated
+from urllib3 import Retry
 
 from titiler.stacapi.enums import MediaType
 from titiler.stacapi.settings import CacheSettings, RetrySettings
-from titiler.stacapi.utils import retry
 
 ResponseType = Literal["json", "html"]
 
@@ -84,36 +86,73 @@ def OutputType(
     return accept_media_type(request.headers.get("accept", ""), accepted_media)
 
 
+class APIParams(TypedDict, total=False):
+    """STAC API Parameters."""
+
+    api_url: str
+    headers: Optional[Dict]
+
+
+def STACApiParams(
+    request: Request,
+) -> APIParams:
+    """Return STAC API Parameters."""
+    return APIParams(
+        api_url=request.app.state.stac_url,
+    )
+
+
 @cached(  # type: ignore
     TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),
-    key=lambda url, collection, item: hashkey(url, collection, item),
+    key=lambda url, collection_id, item_id, headers, **kwargs: hashkey(
+        url, collection_id, item_id, json.dumps(headers)
+    ),
 )
-@retry(
-    tries=retry_config.retry,
-    delay=retry_config.delay,
-    exceptions=(httpx.HTTPError,),
-)
-def get_stac_item(url: str, collection: str, item: str) -> pystac.Item:
+def get_stac_item(
+    url: str,
+    collection_id: str,
+    item_id: str,
+    headers: Optional[Dict] = None,
+) -> pystac.Item:
     """Get STAC Item from STAC API."""
-    r = httpx.get(f"{url}/collections/{collection}/items/{item}")
-    r.raise_for_status()
-    return pystac.Item.from_dict(r.json())
+    stac_api_io = StacApiIO(
+        max_retries=Retry(
+            total=retry_config.retry,
+            backoff_factor=retry_config.retry_factor,
+        ),
+        headers=headers,
+    )
+    results = ItemSearch(
+        f"{url}/search", stac_io=stac_api_io, collections=[collection_id], ids=[item_id]
+    )
+    items = list(results.items())
+    if not items:
+        raise HTTPException(
+            404,
+            f"Could not find Item {item_id} in {collection_id} collection.",
+        )
+
+    return items[0]
 
 
 def ItemIdParams(
-    request: Request,
     collection_id: Annotated[
         str,
         Path(description="STAC Collection Identifier"),
     ],
     item_id: Annotated[str, Path(description="STAC Item Identifier")],
+    api_params=Depends(STACApiParams),
 ) -> pystac.Item:
     """STAC Item dependency for the MultiBaseTilerFactory."""
-    stac_url = request.app.state.stac_url
-    return get_stac_item(stac_url, collection_id, item_id)
+    return get_stac_item(
+        api_params["api_url"],
+        collection_id,
+        item_id,
+        headers=api_params.get("headers", {}),
+    )
 
 
-def STACApiParams(
+def STACSearchParams(
     request: Request,
     collection_id: Annotated[
         str,

--- a/titiler/stacapi/factory.py
+++ b/titiler/stacapi/factory.py
@@ -205,7 +205,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
-                    url=api_params["url"],
+                    url=api_params["api_url"],
                     headers=api_params.get("headers", {}),
                     tms=tms,
                     reader_options={**reader_params},

--- a/titiler/stacapi/factory.py
+++ b/titiler/stacapi/factory.py
@@ -33,6 +33,7 @@ from titiler.core.resources.responses import XMLResponse
 from titiler.core.utils import render_image
 from titiler.mosaic.factory import PixelSelectionParams
 from titiler.stacapi.backend import STACAPIBackend
+from titiler.stacapi.dependencies import APIParams, STACApiParams, STACSearchParams
 
 MOSAIC_THREADS = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
 MOSAIC_STRICT_ZOOM = str(os.getenv("MOSAIC_STRICT_ZOOM", False)).lower() in [
@@ -83,7 +84,9 @@ def check_query_params(
 class MosaicTilerFactory(BaseTilerFactory):
     """Custom MosaicTiler for STACAPI Mosaic Backend."""
 
-    path_dependency: Callable[..., Dict]
+    path_dependency: Callable[..., APIParams] = STACApiParams
+
+    search_dependency: Callable[..., Dict] = STACSearchParams
 
     # In this factory, `reader` should be a Mosaic Backend
     # https://developmentseed.org/cogeo-mosaic/advanced/backends/
@@ -173,7 +176,8 @@ class MosaicTilerFactory(BaseTilerFactory):
                     description="Row (Y) index of the tile on the selected TileMatrix. It cannot exceed the MatrixWidth-1 for the selected TileMatrix.",
                 ),
             ],
-            search_query=Depends(self.path_dependency),
+            api_params=Depends(self.path_dependency),
+            search_query=Depends(self.search_dependency),
             scale: Annotated[  # type: ignore
                 Optional[conint(gt=0, le=4)],
                 "Tile size scale. 1=256x256, 2=512x512...",
@@ -201,7 +205,8 @@ class MosaicTilerFactory(BaseTilerFactory):
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
-                    request.app.state.stac_url,
+                    url=api_params["url"],
+                    headers=api_params.get("headers", {}),
                     tms=tms,
                     reader_options={**reader_params},
                     **backend_params,
@@ -275,7 +280,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported"
                 ),
             ],
-            search_query=Depends(self.path_dependency),
+            search_query=Depends(self.search_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -364,7 +369,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported"
                 ),
             ],
-            search_query=Depends(self.path_dependency),
+            search_query=Depends(self.search_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -440,7 +445,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported"
                 ),
             ],
-            search_query=Depends(self.path_dependency),
+            search_query=Depends(self.search_dependency),
             tile_format: Annotated[
                 ImageType,
                 Query(description="Output image type. Default is png."),

--- a/titiler/stacapi/main.py
+++ b/titiler/stacapi/main.py
@@ -18,7 +18,7 @@ from titiler.core.resources.enums import OptionalHeader
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 from titiler.stacapi import __version__ as titiler_stacapi_version
 from titiler.stacapi import models
-from titiler.stacapi.dependencies import ItemIdParams, OutputType, STACApiParams
+from titiler.stacapi.dependencies import ItemIdParams, OutputType
 from titiler.stacapi.enums import MediaType
 from titiler.stacapi.factory import MosaicTilerFactory
 from titiler.stacapi.reader import STACReader
@@ -89,7 +89,6 @@ if settings.debug:
 # - The `path_dependency` is set to `STACApiParams` which define `{collection_id}`
 # `Path` dependency and other Query parameters used to construct STAC API Search request.
 collection = MosaicTilerFactory(
-    path_dependency=STACApiParams,
     optional_headers=optional_headers,
     router_prefix="/collections/{collection_id}",
     add_viewer=True,

--- a/titiler/stacapi/settings.py
+++ b/titiler/stacapi/settings.py
@@ -60,8 +60,11 @@ class CacheSettings(BaseSettings):
 class RetrySettings(BaseSettings):
     """Retry settings"""
 
+    # Total number of retries to allow.
     retry: Annotated[int, Field(ge=0)] = 3
-    delay: Annotated[float, Field(ge=0.0)] = 0.0
+
+    # A backoff factor to apply between attempts after the second try
+    retry_factor: Annotated[float, Field(ge=0.0)] = 0.0
 
     model_config = {
         "env_prefix": "TITILER_STACAPI_API_",

--- a/titiler/stacapi/utils.py
+++ b/titiler/stacapi/utils.py
@@ -6,37 +6,10 @@ Code from titiler.pgstac and titiler.cmr, MIT License.
 
 import re
 import time
-from typing import Any, Optional, Sequence, Type, Union
+from typing import Any, Optional
 
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates, _TemplateResponse
-
-
-def retry(
-    tries: int,
-    exceptions: Union[Type[Exception], Sequence[Type[Exception]]] = Exception,
-    delay: float = 0.0,
-):
-    """Retry Decorator"""
-
-    def _decorator(func: Any):
-        def _newfn(*args: Any, **kwargs: Any):
-
-            attempt = 0
-            while attempt < tries:
-                try:
-                    return func(*args, **kwargs)
-
-                except exceptions:  # type: ignore
-
-                    attempt += 1
-                    time.sleep(delay)
-
-            return func(*args, **kwargs)
-
-        return _newfn
-
-    return _decorator
 
 
 def create_html_response(


### PR DESCRIPTION
closes #11
closes #10 
closes #9 

This PR does:
- switch from httpx to pystac-client to fetch Item 
- use `StacApiIO` for retry mechanism 
- enable forwarding headers to the stac-api requests
- refactor input parameters for the mosaic backend