### PR TITLE
Fallback to layer id and use urn identifier in tms supportedCRS

### DIFF
--- a/titiler/stacapi/templates/wmts-getcapabilities_1.0.0.xml
+++ b/titiler/stacapi/templates/wmts-getcapabilities_1.0.0.xml
@@ -57,7 +57,7 @@
   <Contents>
   {% for layer in layers %}
     <Layer>
-      <ows:Title>{{ layer.title }}</ows:Title>
+      <ows:Title>{{ layer.title or layer.id }}</ows:Title>
       <ows:WGS84BoundingBox>
         <ows:LowerCorner>{{ layer.bbox[0] }} {{ layer.bbox[1] }}</ows:LowerCorner>
         <ows:UpperCorner>{{ layer.bbox[2] }} {{ layer.bbox[3] }}</ows:UpperCorner>
@@ -113,7 +113,7 @@
   {% for tms in tilematrixsets %}
   <TileMatrixSet>
     <ows:Identifier>{{ tms.id }}</ows:Identifier>
-    <ows:SupportedCRS>{{ tms.crs.srs }}</ows:SupportedCRS>
+    <ows:SupportedCRS>urn:ogc:def:crs:{{ tms.id }}</ows:SupportedCRS>
     {% for matrix in tms %}
       <TileMatrix>
         <ows:Identifier>{{ matrix.id }}</ows:Identifier>

--- a/titiler/stacapi/templates/wmts-getcapabilities_1.0.0.xml
+++ b/titiler/stacapi/templates/wmts-getcapabilities_1.0.0.xml
@@ -113,7 +113,11 @@
   {% for tms in tilematrixsets %}
   <TileMatrixSet>
     <ows:Identifier>{{ tms.id }}</ows:Identifier>
-    <ows:SupportedCRS>urn:ogc:def:crs:{{ tms.id }}</ows:SupportedCRS>
+    {% if tms.crs.to_epsg() %}
+      <ows:SupportedCRS>urn:ogc:def:crs:epsg::{{tms.crs.to_epsg()}}</ows:SupportedCRS>
+    {% else %}
+      <ows:SupportedCRS>{{ tms.crs.srs.replace("http://www.opengis.net/def/", "urn:ogc:def:").replace("/", ":")}} </ows:SupportedCRS>
+    {% endif %}
     {% for matrix in tms %}
       <TileMatrix>
         <ows:Identifier>{{ matrix.id }}</ows:Identifier>


### PR DESCRIPTION
Fallback to layer id if the title is empty because some capability parsers use this ows:Title as the identifier.

Use urn identifier in TMS supportedCRS as this is following the WMTS spec. Also found some processor failing on the srs. Spec example: https://schemas.opengis.net/wmts/1.0/examples/wmtsGetCapabilities_response.xml