### PR TITLE
parse and format rescale array

### DIFF
--- a/tests/test_dependency_params.py
+++ b/tests/test_dependency_params.py
@@ -1,0 +1,30 @@
+"""test get_dependency_params."""
+
+from titiler.core.dependencies import RescalingParams
+from titiler.stacapi.factory import get_dependency_params
+
+
+def test_get_params_rescale():
+    """test get_dependency_params for rescale."""
+
+    def _parse_rescale(rescale):
+        rescales = []
+        for r in qs["rescale"]:
+            if not isinstance(r, str):
+                rescales.append(",".join(map(str, r)))
+            else:
+                rescales.append(r)
+
+        return rescales
+
+    qs = {"rescale": ["0,1", "2,3"]}
+    assert get_dependency_params(
+        dependency=RescalingParams,
+        query_params={"rescale": _parse_rescale(qs)},
+    ) == [(0.0, 1.0), (2.0, 3.0)]
+
+    qs = {"rescale": [[0, 1], [2, 3]]}
+    assert get_dependency_params(
+        dependency=RescalingParams,
+        query_params={"rescale": _parse_rescale(qs)},
+    ) == [(0.0, 1.0), (2.0, 3.0)]

--- a/titiler/stacapi/factory.py
+++ b/titiler/stacapi/factory.py
@@ -810,11 +810,19 @@ class OGCWMTSFactory(BaseTilerFactory):
             ):
                 image = post_process(image)
 
-            if rescale := get_dependency_params(
-                dependency=self.rescale_dependency,
-                query_params=query_params,
-            ):
-                image.rescale(rescale)
+            if "rescale" in query_params:
+                rescales = []
+                for r in query_params["rescale"]:
+                    if not isinstance(r, str):
+                        rescales.append(",".join(map(str, r)))
+                    else:
+                        rescales.append(r)
+
+                if rescale := get_dependency_params(
+                    dependency=self.rescale_dependency,
+                    query_params={"rescale": rescales},
+                ):
+                    image.rescale(rescale)
 
             if color_formula := get_dependency_params(
                 dependency=self.color_formula_dependency,


### PR DESCRIPTION
rescale in the render extension is in form of `rescale: [[0, 1], [2, 3]]`, while titiler expect `rescale: ["0,1", "2,3"]`