### PR TITLE
fix: use GET requests when using CQL2 STAC filters

### DIFF
--- a/tests/test_dependency_params.py
+++ b/tests/test_dependency_params.py
@@ -1,6 +1,7 @@
 """test get_dependency_params."""
 
 from titiler.core.dependencies import RescalingParams
+from titiler.stacapi.dependencies import STACQueryParams
 from titiler.stacapi.factory import get_dependency_params
 
 
@@ -28,3 +29,40 @@ def test_get_params_rescale():
         dependency=RescalingParams,
         query_params={"rescale": _parse_rescale(qs)},
     ) == [(0.0, 1.0), (2.0, 3.0)]
+
+
+def test_get_params_stacquery():
+    """test get_dependency_params for STACQueryParams."""
+
+    qs = {
+        "bbox": "1,2,3,4",
+        "datetime": "2020-01-01/2020-12-31",
+        "limit": 10,
+        "max_items": 100,
+    }
+    assert get_dependency_params(dependency=STACQueryParams, query_params=qs,) == {
+        "method": "POST",
+        "bbox": [1.0, 2.0, 3.0, 4.0],
+        "datetime": "2020-01-01/2020-12-31",
+        "limit": 10,
+        "max_items": 100,
+        "sortby": None,
+        "filter": None,
+    }
+
+    qs = {
+        "bbox": "1,2,3,4",
+        "datetime": "2020-01-01/2020-12-31",
+        "filter": "property=value",
+        "limit": 10,
+        "max_items": 100,
+    }
+    assert get_dependency_params(dependency=STACQueryParams, query_params=qs,) == {
+        "method": "GET",
+        "bbox": [1.0, 2.0, 3.0, 4.0],
+        "datetime": "2020-01-01/2020-12-31",
+        "filter": "property=value",
+        "limit": 10,
+        "max_items": 100,
+        "sortby": None,
+    }

--- a/titiler/stacapi/dependencies.py
+++ b/titiler/stacapi/dependencies.py
@@ -167,13 +167,13 @@ def STACQueryParams(
     query: Annotated[
         Optional[str], Query(description="CQL2 Filter", alias="filter")
     ] = None,
-    filter_lang: Annotated[
-        Optional[Literal["cql2-text", "cql2-json"]],
-        Query(
-            description="CQL2 Language (cql2-text, cql2-json). Defaults to cql2-text.",
-            alias="filter-lang",
-        ),
-    ] = None,
+    # filter_lang: Annotated[
+    #     Optional[Literal["cql2-text", "cql2-json"]],
+    #     Query(
+    #         description="CQL2 Language (cql2-text, cql2-json). Defaults to cql2-text.",
+    #         alias="filter-lang",
+    #     ),
+    # ] = None,
     limit: Annotated[
         Optional[int],
         Query(description="Limit the number of items per page search (default: 10)"),
@@ -185,11 +185,12 @@ def STACQueryParams(
 ) -> Dict:
     """Dependency to construct STAC API Search Query."""
     return {
+        "method": "GET" if query else "POST",
         "bbox": list(map(float, bbox.split(","))) if bbox else None,
         "datetime": datetime,
         "sortby": sortby,
         "filter": query,
-        "filter-lang": filter_lang,
+        # "filter_lang": filter_lang,
         "limit": limit or 10,
         "max_items": max_items or 100,
     }


### PR DESCRIPTION
* Removed filter_lang STAC query param as we only support cql2 text format
* Use GET request when CQL2 filter is passed because STAC API filter extension does not support this for POST requests yet

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
