### PR TITLE
fix: fix dependabot limitation of parsing only FROM lines in docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,11 @@ updates:
       all:
         patterns:
         - "*"
+
+  # Moves the pinned uv image in the Dockerfile.
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 ARG PYTHON_VERSION=3.14
 
+# uv as a pass-through stage rather than a direct COPY --from=<image>:
+# Dependabot only parses FROM lines (dependabot/dependabot-core#5103), so this
+# keeps the version pinned *and* auto-updated by the docker ecosystem.
+FROM ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 AS uv
+
 FROM python:${PYTHON_VERSION}  AS builder
 
 # Set build labels
@@ -19,7 +24,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Configure uv-managed virtual environment
 ENV UV_LINK_MODE=copy \


### PR DESCRIPTION
Pins `COPY --from=ghcr.io/astral-sh/uv:latest` to a tag+digest passed via a `FROM … AS uv` line (the [dependabot/dependabot-core#5103 workaround](https://github.com/dependabot/dependabot-core/issues/5103#issuecomment-1692420920), since Dependabot only parses `FROM` lines — and adds the `docker` ecosystem so the pin gets bumped weekly)

From the discussion in [EOPF-Explorer/titiler-eopf#138](https://github.com/EOPF-Explorer/titiler-eopf/pull/138#discussion_r3719165470).